### PR TITLE
Refetch order query on successful deposit/withdraw action to update vault balances

### DIFF
--- a/__tests__/OrderQuotes.test.tsx
+++ b/__tests__/OrderQuotes.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { vi } from 'vitest';
+import { Mock, vi } from 'vitest';
 import StrategyAnalytics from '@/app/_components/StrategyAnalytics';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { act } from 'react';
 import { quote } from '@rainlanguage/orderbook';
 import QuotesTable from '@/app/_components/QuotesTable';
@@ -10,7 +10,12 @@ vi.mock('@tanstack/react-query', async () => {
 	const actual = await vi.importActual('@tanstack/react-query');
 	return {
 		...actual,
-		useQuery: vi.fn()
+		useQuery: vi.fn(),
+		useQueryClient: vi.fn(() => ({
+			queryClient: {
+				refetchQueries: vi.fn()
+			}
+		}))
 	};
 });
 
@@ -119,6 +124,9 @@ describe('OrderQuotes', () => {
 			isFetching: false,
 			status: 'success',
 			fetchStatus: 'idle'
+		} as any);
+		vi.mocked(useQueryClient).mockReturnValue({
+			refetchQueries: vi.fn()
 		} as any);
 		vi.clearAllMocks();
 	});

--- a/__tests__/StrategyAnalytics.test.tsx
+++ b/__tests__/StrategyAnalytics.test.tsx
@@ -23,7 +23,8 @@ vi.mock(import('@tanstack/react-query'), async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
 		...actual,
-		useQuery: vi.fn()
+		useQuery: vi.fn(),
+		useQueryClient: vi.fn()
 	};
 });
 
@@ -56,7 +57,7 @@ describe('StrategyAnalytics', () => {
 			isError: false,
 			refetch: vi.fn()
 		});
-		render(<StrategyAnalytics transactionId="0xtransaction" network="ethereum" />);
+		render(<StrategyAnalytics orderHash="0xtransaction" network="ethereum" />);
 		expect(screen.getByText('Strategy Analytics')).toBeInTheDocument();
 		expect(screen.getByText(RemovalStatus.Idle)).toBeInTheDocument();
 	});
@@ -78,7 +79,7 @@ describe('StrategyAnalytics', () => {
 			isError: false,
 			refetch: vi.fn()
 		});
-		render(<StrategyAnalytics transactionId="0xtransaction" network="ethereum" />);
+		render(<StrategyAnalytics orderHash="0xtransaction" network="ethereum" />);
 		expect(screen.getByTestId('strategy-status')).toHaveTextContent('Inactive');
 		expect(screen.queryByTestId('remove-strategy-btn')).not.toBeInTheDocument();
 	});
@@ -108,7 +109,7 @@ describe('StrategyAnalytics', () => {
 		});
 		(waitForTransactionReceipt as Mock).mockReturnValue(mockWaitForTransactionReceipt);
 
-		render(<StrategyAnalytics transactionId="0xtransaction" network="flare" />);
+		render(<StrategyAnalytics orderHash="0xtransaction" network="flare" />);
 
 		const removeButton = screen.getByTestId('remove-strategy-btn');
 		expect(removeButton).toHaveTextContent(RemovalStatus.Idle);

--- a/app/_components/StrategyAnalytics.tsx
+++ b/app/_components/StrategyAnalytics.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { getTransactionAnalyticsData } from '@/app/_queries/strategyAnalytics';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { TokenAndBalance } from './TokenAndBalance';
 import { formatTimestampSecondsAsLocal } from '../_services/dates';
 import { Button } from '@/components/ui/button';
@@ -47,6 +47,7 @@ const Property = ({
 const StrategyAnalytics = ({ orderHash, network }: props) => {
 	const { switchChainAsync } = useSwitchChain();
 	const { connectModalOpen, openConnectModal } = useConnectModal();
+	const queryClient = useQueryClient();
 	const query = useQuery({
 		queryKey: [orderHash],
 		queryFn: () => getTransactionAnalyticsData(orderHash, network),
@@ -106,7 +107,11 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 
 	const quotesTableRef = useRef<QuotesTableRef>(null);
 
-	const refetchQuotes = () => {
+	const onDepositWithdrawSuccess = async () => {
+		await queryClient.refetchQueries({
+			queryKey: [orderHash],
+			exact: true
+		});
 		quotesTableRef.current?.getQuotes();
 	};
 
@@ -174,7 +179,7 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 													deposit
 													withdraw
 													network={network}
-													onDepositWithdrawSuccess={refetchQuotes}
+													onDepositWithdrawSuccess={onDepositWithdrawSuccess}
 												/>
 											</div>
 										);
@@ -192,7 +197,7 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 													deposit
 													withdraw
 													network={network}
-													onDepositWithdrawSuccess={refetchQuotes}
+													onDepositWithdrawSuccess={onDepositWithdrawSuccess}
 												/>
 											</div>
 										);


### PR DESCRIPTION
Closes #113

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See issue: #113

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Added query client to call `refetchQueries` on modal success callbacks

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
