### PR TITLE
Re-work getNetworkSubgraphs

### DIFF
--- a/app/_queries/getOrders.tsx
+++ b/app/_queries/getOrders.tsx
@@ -50,7 +50,9 @@ export const getOrders = async (owner?: string) => {
 
 	// make a query for each network
 	const promises: Promise<Order[]>[] = [];
-	Object.entries(networks).forEach(([network, subgraphUrl]) => {
+
+	// Iterate over the array of networks
+	networks.forEach(({ name, subgraphUrl }) => {
 		promises.push(
 			fetch(subgraphUrl, {
 				method: 'POST',
@@ -64,7 +66,7 @@ export const getOrders = async (owner?: string) => {
 					if (res.errors) throw new Error(res.errors[0].message);
 					if (res.data && res.data.orders) {
 						return res.data.orders.map((order: Order) => {
-							order.network = network;
+							order.network = name; // Use the name of the network
 							return order;
 						});
 					}
@@ -74,7 +76,7 @@ export const getOrders = async (owner?: string) => {
 
 	return (await Promise.allSettled(promises))
 		.filter((v) => v.status === 'fulfilled')
-		.map((v) => v.value)
+		.map((v) => (v as PromiseFulfilledResult<Order[]>).value)
 		.flat()
 		.sort((a, b) => +b.timestampAdded - +a.timestampAdded);
 };

--- a/app/_queries/strategyAnalytics.tsx
+++ b/app/_queries/strategyAnalytics.tsx
@@ -76,11 +76,14 @@ export const transactionAnalytics = () => `
 }`;
 
 export const getTransactionAnalyticsData = async (orderHash: string, network: string) => {
-	const subgraphUrl =
-		getNetworkSubgraphs()[network as keyof ReturnType<typeof getNetworkSubgraphs>];
-	if (subgraphUrl) {
+	// Find the network's subgraph by matching the network name
+	const subgraphInfo = getNetworkSubgraphs().find(
+		(net) => net.name.toLowerCase() === network.toLowerCase()
+	);
+
+	if (subgraphInfo?.subgraphUrl) {
 		try {
-			const response = await fetch(subgraphUrl, {
+			const response = await fetch(subgraphInfo.subgraphUrl, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'
@@ -101,7 +104,7 @@ export const getTransactionAnalyticsData = async (orderHash: string, network: st
 				);
 				return {
 					...orderByHash,
-					order: { ...orderByHash.order, network, subgraphUrl }
+					order: { ...orderByHash.order, network, subgraphUrl: subgraphInfo.subgraphUrl }
 				};
 			}
 		} catch (error: unknown) {

--- a/app/_queries/subgraphs.tsx
+++ b/app/_queries/subgraphs.tsx
@@ -1,14 +1,46 @@
-export const getNetworkSubgraphs = () => {
-	return {
-		flare:
-			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/0.8/gn',
-		base: 'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.9/gn',
-		bsc: 'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-bsc/2024-10-14-63f4/gn',
-		linea:
-			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-linea/2024-10-14-12fc/gn',
-		arbitrum:
-			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-arbitrum/0.2/gn',
-		polygon:
-			'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.6/gn'
-	};
+type Network = {
+	chainId: number;
+	name: string;
+	subgraphUrl: string;
+};
+
+export const getNetworkSubgraphs = (): Network[] => {
+	return [
+		{
+			chainId: 14,
+			name: 'flare',
+			subgraphUrl:
+				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/0.8/gn'
+		},
+		{
+			chainId: 8453,
+			name: 'base',
+			subgraphUrl:
+				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.9/gn'
+		},
+		{
+			chainId: 56,
+			name: 'bsc',
+			subgraphUrl:
+				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-bsc/2024-10-14-63f4/gn'
+		},
+		{
+			chainId: 59144,
+			name: 'linea',
+			subgraphUrl:
+				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-linea/2024-10-14-12fc/gn'
+		},
+		{
+			chainId: 42161,
+			name: 'arbitrum',
+			subgraphUrl:
+				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-arbitrum/0.2/gn'
+		},
+		{
+			chainId: 137,
+			name: 'polygon',
+			subgraphUrl:
+				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.6/gn'
+		}
+	];
 };


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

getNetworkSubgraphs returns an object with keyed subgraph URLs. Since the keys are not the same as network names in viem's Network type, it becomes difficult to get complete chain information. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Conver the return type to an object which contains chainId and SG URL, so that we can retrieve the SG for the connected wallet, not just a strat wallet. This is useful for polling the correct SG url before a deployment exists.

Closes #223


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
