### PR TITLE
2024 10 28 pai

### DIFF
--- a/app/_queries/subgraphs.tsx
+++ b/app/_queries/subgraphs.tsx
@@ -41,6 +41,12 @@ export const getNetworkSubgraphs = (): Network[] => {
 			name: 'polygon',
 			subgraphUrl:
 				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.6/gn'
+		},
+		{
+			chainId: 1,
+			name: 'ethereum',
+			subgraphUrl:
+				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-mainnet/2024-10-25-af6a/gn'
 		}
 	];
 };

--- a/app/_queries/subgraphs.tsx
+++ b/app/_queries/subgraphs.tsx
@@ -44,7 +44,7 @@ export const getNetworkSubgraphs = (): Network[] => {
 		},
 		{
 			chainId: 1,
-			name: 'ethereum',
+			name: 'mainnet',
 			subgraphUrl:
 				'https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-mainnet/2024-10-25-af6a/gn'
 		}

--- a/app/_services/parseDotrainFrontmatter.tsx
+++ b/app/_services/parseDotrainFrontmatter.tsx
@@ -1,4 +1,4 @@
-import { toHex } from 'viem';
+import { pad, toBytes, toHex } from 'viem';
 import { YamlData } from '../_types/yamlData';
 import _ from 'lodash';
 
@@ -6,7 +6,7 @@ export const getOrderDetailsGivenDeployment = (yamlData: YamlData, deploymentOpt
 	const deployment = yamlData.deployments[deploymentOption];
 	const order = yamlData.orders[deployment.order];
 	const orderBook = yamlData.orderbooks[order.orderbook];
-	const orderBookAddress = toHex(BigInt(orderBook.address));
+	const orderBookAddress = toHex(pad(toBytes(BigInt(orderBook.address)), { size: 20 }));
 	const network = yamlData.networks[order.network];
 
 	const tokens = yamlData.tokens;

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1039,7 +1039,7 @@ gui:
         - binding: min-amount
           name: Minimum amount
           description: The minimum amount of WETH that will be offered in a single auction.
-          min: 0
+          min: 0.001
           presets:
             - name: 0.001 WETH
               value: 0.001

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1019,10 +1019,12 @@ gui:
               value: 14400
             - name: 8 hours (28800)
               value: 28800
+            - name: 24 hours (86400)
+              value: 86400
         - binding: max-amount
           name: Max amount
           description: The maximum amount of WETH that will be offered in a single auction.
-          min: 3
+          min: 1
           presets:
             - name: 3 WETH
               value: 3

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1015,10 +1015,6 @@ gui:
           description: The amount of time (in seconds) between halvings of the price and the amount offered during each auction, relative to their baselines.
           min: 600
           presets:
-            - name: 1 hour (3600)
-              value: 3600
-            - name: 2 hours (7200)
-              value: 7200
             - name: 4 hours (14400)
               value: 14400
             - name: 8 hours (28800)
@@ -1026,29 +1022,29 @@ gui:
         - binding: max-amount
           name: Max amount
           description: The maximum amount of WETH that will be offered in a single auction.
-          min: 0
+          min: 3
           presets:
-            - name: 0.005 WETH
-              value: 0.005
-            - name: 0.01 WETH
-              value: 0.01 
-            - name: 0.02 WETH
-              value: 0.02
-            - name: 0.05 WETH
-              value: 0.05
+            - name: 3 WETH
+              value: 3
+            - name: 5 WETH
+              value: 5
+            - name: 10 WETH
+              value: 10
+            - name: 20 WETH
+              value: 20
         - binding: min-amount
           name: Minimum amount
           description: The minimum amount of WETH that will be offered in a single auction.
-          min: 0.001
+          min: 1
           presets:
-            - name: 0.001 WETH
-              value: 0.001
-            - name: 0.002 WETH
-              value: 0.002
-            - name: 0.005 WETH
-              value: 0.005
-            - name: 0.01 WETH
-              value: 0.01
+            - name: 1 WETH
+              value: 1
+            - name: 1.25 WETH
+              value: 1.25
+            - name: 1.5 WETH
+              value: 1.5
+            - name: 2 WETH
+              value: 2
       deposits:
         - token: ethereum-pai
           min: 0

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -982,7 +982,7 @@ gui:
       fields:
         - binding: initial-io
           name: Initial price (PAI per WETH)
-          description: The rough USD price you see for WETH on Dextools (e.g. 2500).
+          description: The rough WETH price you see for PAI on Dextools (e.g. 0.0001205).
           min: 1
         - binding: next-trade-multiplier
           name: Next trade multiplier

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -983,7 +983,7 @@ gui:
         - binding: initial-io
           name: Initial price (PAI per WETH)
           description: The rough WETH price you see for PAI on Dextools (e.g. 0.0001205).
-          min: 1
+          min: 0
         - binding: next-trade-multiplier
           name: Next trade multiplier
           description: This is the most the strategy will move the price in a single trade. Larger numbers will capture larger price jumps but trade less often, smaller numbers will trade more often but be less defensive against large price jumps in the market.

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -975,6 +975,97 @@ gui:
             - 0.05
             - 0.2
             - 0.4
+    - deployment: ethereum-pai-weth
+      name: PAI<>WETH on Ethereum.
+      description: Rotate PAI and WETH on Ethereum.
+
+      fields:
+        - binding: initial-io
+          name: Initial price (PAI per WETH)
+          description: The rough USD price you see for WETH on Dextools (e.g. 2500).
+          min: 1
+        - binding: next-trade-multiplier
+          name: Next trade multiplier
+          description: This is the most the strategy will move the price in a single trade. Larger numbers will capture larger price jumps but trade less often, smaller numbers will trade more often but be less defensive against large price jumps in the market.
+          min: 1
+          presets:
+            - name: 1.01x
+              value: 1.01
+            - name: 1.02x
+              value: 1.02
+            - name: 1.05x
+              value: 1.05
+        - binding: cost-basis-multiplier
+          name: Cost basis multiplier
+          description: The minimum spread applied to the breakeven in addition to the auction. This is applied in both directions so 1.01x would be a 2% total spread.
+          min: 1
+          presets:
+            - name: 1 (auction spread only)
+              value: 1
+            - name: 1.0005x (0.1% total)
+              value: 1.0005
+            - name: 1.001x (0.2% total)
+              value: 1.001
+            - name: 1.0025x (0.5% total)
+              value: 1.0025
+            - name: 1.005x (1% total)
+              value: 1.005
+        - binding: time-per-epoch
+          name: Time per halving (seconds)
+          description: The amount of time (in seconds) between halvings of the price and the amount offered during each auction, relative to their baselines.
+          min: 600
+          presets:
+            - name: 1 hour (3600)
+              value: 3600
+            - name: 2 hours (7200)
+              value: 7200
+            - name: 4 hours (14400)
+              value: 14400
+            - name: 8 hours (28800)
+              value: 28800
+        - binding: max-amount
+          name: Max amount
+          description: The maximum amount of PAI that will be offered in a single auction.
+          min: 1
+          presets:
+            - name: $10
+              value: 10
+            - name: $20
+              value: 20
+            - name: $50
+              value: 50
+            - name: $100
+              value: 100
+        - binding: min-amount
+          name: Minimum amount
+          description: The minimum amount of PAI that will be offered in a single auction.
+          min: 1
+          presets:
+            - name: $1
+              value: 1
+            - name: $2
+              value: 2
+            - name: $5
+              value: 5
+            - name: $10
+              value: 10
+      deposits:
+        - token: ethereum-pai
+          min: 0
+          presets:
+            - 0
+            - 1000
+            - 5000
+            - 10000
+        - token: ethereum-weth
+          min: 0
+          presets:
+            - 0
+            - 0.5
+            - 2
+            - 4
+
+
 
 scenarios:
   arbitrum:
@@ -1077,6 +1168,19 @@ scenarios:
           amount-token: 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
           initial-output-token: 0xd0e9c8f5Fae381459cf07Ec506C1d2896E8b5df6
           initial-input-token: 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
+  ethereum:
+    orderbook: ethereum
+    runs: 1
+    bindings:
+      raindex-subparser: 0x22410e2a46261a1B1e3899a072f303022801C764
+      history-cap: '1e50'
+    scenarios:
+      pai-weth:
+        runs: 1
+        bindings:
+          amount-token: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+          initial-output-token: 0x13E4b8CfFe704d3De6F19E52b201d92c21EC18bD
+          initial-input-token: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 
 networks:
   flare:
@@ -1099,18 +1203,25 @@ networks:
     chain-id: 137
     network-id: 137
     currency: POL
+  ethereum:
+    rpc: https://rpc.ankr.com/eth
+    chain-id: 1
+    network-id: 1
+    currency: ETH
 
 metaboards:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-base-0x59401C93/0.1/gn
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
+  ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
 
 subgraphs:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/0.2/gn
   base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.7/gn
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-arbitrum/0.1/gn
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.4/gn
+  ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-mainnet/2024-10-25-af6a/gn
 
 orderbooks:
   flare:
@@ -1127,6 +1238,10 @@ orderbooks:
     address: 0x7D2f700b1f6FD75734824EA4578960747bdF269A
     network: polygon
     subgraph: polygon
+  ethereum:
+    address: 0x0eA6d458488d1cf51695e1D6e4744e6FB715d37C
+    network: ethereum
+    subgraph: ethereum
 
 deployers:
   flare:
@@ -1140,6 +1255,9 @@ deployers:
   polygon:
     address: 0xE7116BC05C8afe25e5B54b813A74F916B5D42aB1
     network: polygon
+  ethereum:
+    address: 0xd19581a021f4704ad4eBfF68258e7A0a9DB1CD77
+    network: ethereum
 
 tokens:
   arbitrum-usdc:
@@ -1206,6 +1324,14 @@ tokens:
     network: polygon
     address: 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
     decimals: 6
+  ethereum-pai:
+    network: ethereum
+    address: 0x13E4b8CfFe704d3De6F19E52b201d92c21EC18bD
+    decimals: 18
+  ethereum-weth:
+    network: ethereum
+    address: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+    decimals: 18
 
 orders:
   arbitrum-wbtc-weth:
@@ -1307,6 +1433,15 @@ orders:
     outputs:
       - token: polygon-usdc
       - token: polygon-ioen
+  ethereum-pai-weth:
+    network: ethereum
+    orderbook: ethereum
+    inputs:
+      - token: ethereum-pai
+      - token: ethereum-weth
+    outputs:
+      - token: ethereum-pai
+      - token: ethereum-weth
 
 deployments:
   arbitrum-wbtc-weth:
@@ -1342,6 +1477,9 @@ deployments:
   polygon-usdc-ioen:
     order: polygon-usdc-ioen
     scenario: polygon.usdc-ioen
+  ethereum-pai-weth:
+    order: ethereum-pai-weth
+    scenario: ethereum.pai-weth
 ---
 #raindex-subparser !Subparser for the Raindex.
 

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -981,7 +981,7 @@ gui:
 
       fields:
         - binding: initial-io
-          name: Initial price (PAI per WETH)
+          name: Initial price (WETH per PAI)
           description: The rough WETH price you see for PAI on Dextools (e.g. 0.0001205).
           min: 0
         - binding: next-trade-multiplier

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1025,30 +1025,30 @@ gui:
               value: 28800
         - binding: max-amount
           name: Max amount
-          description: The maximum amount of PAI that will be offered in a single auction.
-          min: 1
+          description: The maximum amount of WETH that will be offered in a single auction.
+          min: 0
           presets:
-            - name: $10
-              value: 10
-            - name: $20
-              value: 20
-            - name: $50
-              value: 50
-            - name: $100
-              value: 100
+            - name: 0.005 WETH
+              value: 0.005
+            - name: 0.01 WETH
+              value: 0.01 
+            - name: 0.02 WETH
+              value: 0.02
+            - name: 0.05 WETH
+              value: 0.05
         - binding: min-amount
           name: Minimum amount
-          description: The minimum amount of PAI that will be offered in a single auction.
-          min: 1
+          description: The minimum amount of WETH that will be offered in a single auction.
+          min: 0
           presets:
-            - name: $1
-              value: 1
-            - name: $2
-              value: 2
-            - name: $5
-              value: 5
-            - name: $10
-              value: 10
+            - name: 0.001 WETH
+              value: 0.001
+            - name: 0.002 WETH
+              value: 0.002
+            - name: 0.005 WETH
+              value: 0.005
+            - name: 0.01 WETH
+              value: 0.01
       deposits:
         - token: ethereum-pai
           min: 0


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This pull request introduces significant updates to the Ethereum network integration and enhancements to the `dynamic-spread-fast` strategy. The changes include adding support for Ethereum in various configurations and improving the parsing logic for order details.

### Ethereum Network Integration:
* Added Ethereum network configuration, including RPC, chain ID, network ID, and currency details in `public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`.
* Included Ethereum-specific subgraphs, orderbooks, deployers, tokens, and orders in `public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`. [[1]](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1171-R1183) [[2]](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1241-R1244) [[3]](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1258-R1260) [[4]](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1327-R1334) [[5]](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1436-R1444) [[6]](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1480-R1482)

### Strategy Enhancements:
* Added a new deployment strategy `ethereum-pai-weth` with detailed fields, presets, and descriptions in `public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`.

### Parsing Logic Improvement:
* Updated the `getOrderDetailsGivenDeployment` function to pad the `orderBookAddress` to a size of 20 bytes in `app/_services/parseDotrainFrontmatter.tsx`.

### Subgraph Additions:
* Added Mainnet subgraph details to `getNetworkSubgraphs` in `app/_queries/subgraphs.tsx`.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
