### PR TITLE
2024 10 29 clip

### DIFF
--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1065,6 +1065,92 @@ gui:
             - 2
             - 4
 
+    - deployment: linea-clip-weth
+      name: CLIP<>WETH on Linea.
+      description: Rotate CLIP and WETH on Linea.
+
+      fields:
+        - binding: initial-io
+          name: Initial price (WETH per CLIP)
+          description: The rough WETH price you see for CLIP on Dextools.
+          min: 0
+        - binding: next-trade-multiplier
+          name: Next trade multiplier
+          description: This is the most the strategy will move the price in a single trade. Larger numbers will capture larger price jumps but trade less often, smaller numbers will trade more often but be less defensive against large price jumps in the market.
+          min: 1
+          presets:
+            - name: 1.01x
+              value: 1.01
+            - name: 1.02x
+              value: 1.02
+            - name: 1.05x
+              value: 1.05
+        - binding: cost-basis-multiplier
+          name: Cost basis multiplier
+          description: The minimum spread applied to the breakeven in addition to the auction. This is applied in both directions so 1.01x would be a 2% total spread.
+          min: 1
+          presets:
+            - name: 1 (auction spread only)
+              value: 1
+            - name: 1.0005x (0.1% total)
+              value: 1.0005
+            - name: 1.001x (0.2% total)
+              value: 1.001
+            - name: 1.0025x (0.5% total)
+              value: 1.0025
+            - name: 1.005x (1% total)
+              value: 1.005
+        - binding: time-per-epoch
+          name: Time per halving (seconds)
+          description: The amount of time (in seconds) between halvings of the price and the amount offered during each auction, relative to their baselines.
+          min: 600
+          presets:
+            - name: 1 hour (3600)
+              value: 3600
+            - name: 2 hours (7200)
+              value: 7200
+            - name: 4 hours (14400)
+              value: 14400
+            - name: 8 hours (28800)
+              value: 28800
+        - binding: max-amount
+          name: Max amount
+          description: The maximum amount of WETH that will be offered in a single auction.
+          min: 0
+          presets:
+            - name: 0.1 ETH
+              value: 0.1
+            - name: 1 ETH
+              value: 1
+            - name: 10 ETH
+              value: 10
+        - binding: min-amount
+          name: Minimum amount
+          description: The minimum amount of WETH that will be offered in a single auction.
+          min: 0
+          presets:
+            - name: 0.01 ETH
+              value: 0.01
+            - name: 0.1 ETH
+              value: 0.1
+            - name: 1 ETH
+              value: 1
+
+      deposits:
+        - token: linea-clip
+          min: 0
+          presets:
+            - 0
+            - 100
+            - 1000
+            - 10000
+        - token: linea-weth
+          min: 0
+          presets:
+            - 0
+            - 0.1
+            - 1
+            - 10
 
 
 scenarios:
@@ -1181,6 +1267,19 @@ scenarios:
           amount-token: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
           initial-output-token: 0x13E4b8CfFe704d3De6F19E52b201d92c21EC18bD
           initial-input-token: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+  linea:
+    orderbook: linea
+    runs: 1
+    bindings:
+      raindex-subparser: 0xF77b3c3f61af5a3cE7f7CE3cfFc117491104432E
+      history-cap: '1e50'
+    scenarios:
+      clip-weth:
+        runs: 1
+        bindings:
+          amount-token: 0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f
+          initial-output-token: 0x4Ea77a86d6E70FfE8Bb947FC86D68a7F086f198a
+          initial-input-token: 0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f
 
 networks:
   flare:
@@ -1208,6 +1307,11 @@ networks:
     chain-id: 1
     network-id: 1
     currency: ETH
+  linea:
+    rpc: https://rpc.linea.build
+    chain-id: 59144
+    network-id: 59144
+    currency: ETH
 
 metaboards:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-flare-0x893BBFB7/0.1/gn
@@ -1215,6 +1319,7 @@ metaboards:
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-arbitrum/0.1/gn
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-polygon/0.1/gn
   ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-mainnet/2024-10-25-2857/gn
+  linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/mb-linea-0xed7d6156/1.0.0/gn
 
 subgraphs:
   flare: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-flare/0.2/gn
@@ -1222,6 +1327,7 @@ subgraphs:
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-arbitrum/0.1/gn
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.4/gn
   ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-mainnet/2024-10-25-af6a/gn
+  linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-linea/0.1/gn
 
 orderbooks:
   flare:
@@ -1242,6 +1348,10 @@ orderbooks:
     address: 0x0eA6d458488d1cf51695e1D6e4744e6FB715d37C
     network: ethereum
     subgraph: ethereum
+  linea:
+    address: 0x22410e2a46261a1B1e3899a072f303022801C764
+    network: linea
+    subgraph: linea
 
 deployers:
   flare:
@@ -1258,6 +1368,9 @@ deployers:
   ethereum:
     address: 0xd19581a021f4704ad4eBfF68258e7A0a9DB1CD77
     network: ethereum
+  linea:
+    address: 0xA2f56F8F74B7d04d61f281BE6576b6155581dcBA
+    network: linea
 
 tokens:
   arbitrum-usdc:
@@ -1331,6 +1444,14 @@ tokens:
   ethereum-weth:
     network: ethereum
     address: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+    decimals: 18
+  linea-clip:
+    network: linea
+    address: 0x4Ea77a86d6E70FfE8Bb947FC86D68a7F086f198a
+    decimals: 18
+  linea-weth:
+    network: linea
+    address: 0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f
     decimals: 18
 
 orders:
@@ -1442,6 +1563,15 @@ orders:
     outputs:
       - token: ethereum-pai
       - token: ethereum-weth
+  linea-clip-weth:
+    network: linea
+    orderbook: linea
+    inputs:
+      - token: linea-clip
+      - token: linea-weth
+    outputs:
+      - token: linea-clip
+      - token: linea-weth
 
 deployments:
   arbitrum-wbtc-weth:
@@ -1480,6 +1610,9 @@ deployments:
   ethereum-pai-weth:
     order: ethereum-pai-weth
     scenario: ethereum.pai-weth
+  linea-clip-weth:
+    order: linea-clip-weth
+    scenario: linea.clip-weth
 ---
 #raindex-subparser !Subparser for the Raindex.
 

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1129,14 +1129,14 @@ gui:
         - binding: min-amount
           name: Minimum amount
           description: The minimum amount of WETH that will be offered in a single auction.
-          min: 0
+          min: 0.02
           presets:
-            - name: 0.01 ETH
-              value: 0.01
-            - name: 0.1 ETH
-              value: 0.1
-            - name: 1 ETH
-              value: 1
+            - name: 0.02 ETH
+              value: 0.02
+            - name: 0.2 ETH
+              value: 0.2
+            - name: 2 ETH
+              value: 2
 
       deposits:
         - token: linea-clip

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1118,7 +1118,7 @@ gui:
         - binding: max-amount
           name: Max amount
           description: The maximum amount of WETH that will be offered in a single auction.
-          min: 0.005
+          min: 0.02
           presets:
             - name: 0.1 ETH
               value: 0.1
@@ -1129,7 +1129,7 @@ gui:
         - binding: min-amount
           name: Minimum amount
           description: The minimum amount of WETH that will be offered in a single auction.
-          min: 0.02
+          min: 0.005
           presets:
             - name: 0.02 ETH
               value: 0.02

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1026,8 +1026,10 @@ gui:
         - binding: max-amount
           name: Max amount
           description: The maximum amount of WETH that will be offered in a single auction.
-          min: 3
+          min: 1
           presets:
+            - name: 1 WETH
+              value: 1
             - name: 3 WETH
               value: 3
             - name: 5 WETH

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1073,7 +1073,7 @@ gui:
 
       fields:
         - binding: initial-io
-          name: Initial price (WETH per CLIP)
+          name: Initial price (WETH per CLIP) (e.g. 0.000049801852465796 WETH per CLIP)
           description: The rough WETH price you see for CLIP on Dextools.
           min: 0
         - binding: next-trade-multiplier
@@ -1118,7 +1118,7 @@ gui:
         - binding: max-amount
           name: Max amount
           description: The maximum amount of WETH that will be offered in a single auction.
-          min: 0
+          min: 0.005
           presets:
             - name: 0.1 ETH
               value: 0.1
@@ -1329,7 +1329,7 @@ subgraphs:
   arbitrum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-arbitrum/0.1/gn
   polygon: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-polygon/0.4/gn
   ethereum: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-mainnet/2024-10-25-af6a/gn
-  linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-linea/0.1/gn
+  linea: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-linea/2024-10-14-12fc/gn
 
 orderbooks:
   flare:

--- a/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
+++ b/public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain
@@ -1019,6 +1019,10 @@ gui:
               value: 14400
             - name: 8 hours (28800)
               value: 28800
+            - name: 12 hours (43200)
+              value: 43200
+            - name: 24 hours (86400)
+              value: 86400
         - binding: max-amount
           name: Max amount
           description: The maximum amount of WETH that will be offered in a single auction.


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

merge after #240, update base to main

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This pull request introduces support for the Linea network in the `2-dynamic-spread-fast` strategy. The changes include adding new deployment configurations, scenarios, networks, orderbooks, deployers, tokens, and orders related to the Linea network.

Support for Linea network:

* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1068-R1153): Added a new deployment configuration for `linea-clip-weth`, including fields for initial price, trade multipliers, cost basis multipliers, time per epoch, max and min amounts, and deposits.
* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1270-R1282): Added a new scenario for `linea.clip-weth` including bindings for tokens and initial inputs and outputs.
* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1310-R1330): Added `linea` to the `networks` section with its RPC URL, chain ID, and network ID.
* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1351-R1354): Added `linea` to the `orderbooks` section with its address and subgraph.
* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1371-R1373): Added `linea` to the `deployers` section with its address.
* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1448-R1455): Added `linea-clip` and `linea-weth` to the `tokens` section with their addresses and decimals.
* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1566-R1574): Added `linea-clip-weth` to the `orders` section with its network, orderbook, inputs, and outputs.
* [`public/_strategies/raindex/2-dynamic-spread-fast/dynamic-spread-fast.rain`](diffhunk://#diff-366308ec54479692e6bbbc666ce8f7756a63b61f798175320b62c1826de75dc1R1613-R1615): Added `linea-clip-weth` to the `deployments` section with its order and scenario.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
