### PR TITLE
isOwner fix for strategy page

### DIFF
--- a/__tests__/StrategyAnalytics.test.tsx
+++ b/__tests__/StrategyAnalytics.test.tsx
@@ -39,13 +39,16 @@ vi.mock('@wagmi/core', () => ({
 describe('StrategyAnalytics', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useAccount as Mock).mockReturnValue({ address: '0x123', chain: { id: 1 } });
+		(useAccount as Mock).mockReturnValue({
+			address: '0x1234567890123456789012345678901234567890',
+			chain: { id: 1 }
+		});
 		(useSwitchChain as Mock).mockReturnValue({ switchChainAsync: vi.fn() });
 		(useWriteContract as Mock).mockReturnValue({ writeContractAsync: vi.fn() });
 		(waitForTransactionReceipt as Mock).mockReturnValue({ confirmations: 1 });
 	});
 
-	it('renders the strategy details and removal button', () => {
+	it('renders the strategy details and removal button', async () => {
 		(useQuery as Mock).mockImplementationOnce(() => ({
 			data: {
 				active: true,
@@ -54,18 +57,18 @@ describe('StrategyAnalytics', () => {
 				inputs: [],
 				outputs: [],
 				trades: [],
-				addEvents: [{ transaction: { id: '0xtransaction', timestamp: '1700000000' } }]
+				addEvents: [{ transaction: { id: '0xtransaction', timestamp: '1700000000' } }],
+				owner: '0x1234567890123456789012345678901234567890'
 			},
 			isLoading: false,
 			isError: false,
 			refetch: vi.fn()
 		}));
-		(useQuery as Mock).mockImplementationOnce(() => ({
-			data: []
-		}));
 		render(<StrategyAnalytics orderHash="0xtransaction" network="flare" />);
 		expect(screen.getByText('Strategy Analytics')).toBeInTheDocument();
-		expect(screen.getByText(RemovalStatus.Idle)).toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.getByText(RemovalStatus.Idle)).toBeInTheDocument();
+		});
 	});
 
 	it('renders no removal button if the strategy is inactive', () => {
@@ -103,7 +106,8 @@ describe('StrategyAnalytics', () => {
 						inputs: [],
 						outputs: [],
 						trades: [],
-						addEvents: [{ transaction: { id: '0xtransaction', timestamp: '1700000000' } }]
+						addEvents: [{ transaction: { id: '0xtransaction', timestamp: '1700000000' } }],
+						owner: '0x1234567890123456789012345678901234567890'
 					},
 					isLoading: false,
 					isError: false,

--- a/app/_components/StrategyAnalytics.tsx
+++ b/app/_components/StrategyAnalytics.tsx
@@ -129,6 +129,9 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 		}
 	}, [query]);
 
+	// is the owner of the strategy the connected wallet?
+	const isOwner = address && isAddressEqual(getAddress(address), getAddress(query.data.owner));
+
 	return (
 		<div className="container flex-grow pt-8 pb-safe">
 			{!subgraphUrl && <div data-testid="no-sg-error">No subgraph found for this network</div>}
@@ -144,19 +147,17 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 									data-testid="strategy-status"
 									size="2xl"
 									className="py-2 px-4"
-									color={query.data.active ? 'green' : 'red'}
-								>
+									color={query.data.active ? 'green' : 'red'}>
 									{query.data.active ? 'Active' : 'Inactive'}
 								</Badge>
 
-								{query.data.active && (
+								{query.data.active && isOwner && (
 									<Button
 										data-testid="remove-strategy-btn"
 										className={removalStatus !== RemovalStatus.Idle ? 'animate-pulse' : ''}
 										onClick={() => {
 											removeOrder();
-										}}
-									>
+										}}>
 										{removalStatus}
 									</Button>
 								)}
@@ -197,10 +198,7 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 													withdraw
 													network={network}
 													onDepositWithdrawSuccess={refetchQuotes}
-													showDepositWithdraw={isAddressEqual(
-														getAddress(address || ''),
-														getAddress(query.data.owner)
-													)}
+													showDepositWithdraw={isOwner}
 												/>
 											</div>
 										);
@@ -219,10 +217,7 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 													withdraw
 													network={network}
 													onDepositWithdrawSuccess={refetchQuotes}
-													showDepositWithdraw={isAddressEqual(
-														getAddress(address || ''),
-														getAddress(query.data.owner)
-													)}
+													showDepositWithdraw={isOwner}
 												/>
 											</div>
 										);

--- a/app/_components/StrategyAnalytics.tsx
+++ b/app/_components/StrategyAnalytics.tsx
@@ -130,7 +130,12 @@ const StrategyAnalytics = ({ orderHash, network }: props) => {
 	}, [query]);
 
 	// is the owner of the strategy the connected wallet?
-	const isOwner = address && isAddressEqual(getAddress(address), getAddress(query.data.owner));
+	const isOwner =
+		address &&
+		query?.data?.owner &&
+		isAddressEqual(getAddress(address), getAddress(query.data.owner));
+
+	console.log({ address, owner: query?.data?.owner });
 
 	return (
 		<div className="container flex-grow pt-8 pb-safe">


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Was getting a 500 on strat pages when visiting without a wallet connected.

## Solution

Needed to make sure both addresses exist before running them through `getAddress`

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)
