### PR TITLE
Make disclaimer dialog scroll within a safe max height

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
 		<DialogPrimitive.Content
 			ref={ref}
 			className={cn(
-				'max-h-[80vh] fixed left-[50%] top-[50%] z-50 grid w-full max-w-5xl translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-12 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+				'max-h-screen-safe overflow-y-auto fixed left-[50%] top-[50%] z-50 grid w-full max-w-5xl translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-12 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
 				className
 			)}
 			{...props}


### PR DESCRIPTION
## What

On some screen sizes the disclaimer modal filled the whole screen and its content overflowed without any way to scroll (issue #18).

`DialogContent` had `max-h-[80vh]` but no `overflow-y`, so when the content was taller than the cap it spilled out instead of scrolling.

This swaps the height cap to `max-h-screen-safe` (the safe inside height from the `tailwindcss-safe-area` plugin the issue author added for exactly this) and adds `overflow-y-auto`, so tall disclaimer content scrolls within the dialog. CSS-only, no behavioral change to the dialog otherwise.

```diff
-				'max-h-[80vh] fixed left-[50%] top-[50%] ...
+				'max-h-screen-safe overflow-y-auto fixed left-[50%] top-[50%] ...
```

The `max-h-screen-safe` utility compiles to:
`max-height: calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)))`

## Verification

- `npm run build` green
- `npm run lint-check` green (only pre-existing unused-eslint-disable warnings, none in the changed file)

Closes #18