### PR TITLE
ci: adopt rainix nix-cachix-setup composite, drop deprecated DeterminateSystems nix installer

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -18,9 +18,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Run ${{ matrix.task }}
         run: nix develop -c ${{ matrix.task }}
   format-check:
@@ -31,8 +32,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix develop -c npm run format-check
   lint:
     runs-on: ubuntu-latest
@@ -42,8 +45,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix develop -c npm run lint-check
   test:
     runs-on: ubuntu-latest
@@ -53,7 +58,9 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix develop -c npm run test


### PR DESCRIPTION
Closes #356

## What

Replaces the deprecated `DeterminateSystems/nix-installer-action` (+ `magic-nix-cache-action`) in all four jobs of `.github/workflows/rainix.yaml` (`standard-tests`, `format-check`, `lint`, `test`) with the org-standard shared composite `rainlanguage/rainix/.github/actions/nix-cachix-setup@main`, which bundles nix-quick-install + Cachix + `cache-nix-action` and pins every third-party action to an exact SHA (single source of truth — "rainix owns shared CI"). Each job keeps its own pre-existing `actions/checkout` step (with `submodules: recursive` + `fetch-depth: 0`), so the composite is called with `checkout: 'false'`.

This is the same swap already applied and green on the sibling PRs rainlanguage/sqlite-web#31, rainlanguage/rain.subgraph.docker#13, rainlanguage/rainlang-codemirror#32, rainlanguage/rain.subgraph.cli#13, and rainlanguage/rain.solver#460.

## QA

CI-infrastructure-only change: it touches a single GitHub Actions workflow file and no source or test code, so there is no behavioral code surface to mutation-test — the discriminating oracle is the CI run itself.

- **Discriminating oracle:** `rainix.yaml` runs `on: [push]`, so this PR's branch push triggers all four jobs, each of which must install Nix via the composite and run `nix develop -c ...`. A mis-reference (wrong action path or input name) fails the setup step, so the swap is CI-green-discriminating, not a silent no-op.
- **Independent confirmation:** the identical installer + `magic-nix-cache` → composite swap is already green on the sibling PRs above; the composite's input contract (`checkout`, `cachix-auth-token`) matches `nix-cachix-setup/action.yml` on `rainix@main`.
- **Equivalence:** the composite provides the same capabilities the two removed steps did (Nix install + a Nix store cache) plus the org's pinned-SHA hardening. `checkout: 'false'` preserves each job's existing `actions/checkout` (keeping `submodules: recursive` + `fetch-depth: 0`). An empty `CACHIX_AUTH_TOKEN` degrades to a read-only Cachix pull (the composite's documented default), so the jobs stay green whether or not the repo sets that secret. The `nix develop -c` run-steps are untouched.
- **Category check:** issue asks to replace the deprecated installer with the org-standard install (preferred: adopt the shared composite) in every referenced workflow location and verify CI stays green — all four references swapped → Closes #356.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use the Rainix setup for Nix and Cachix across standard checks, formatting, linting, and tests.
  * Improved consistency of environment setup and caching during automated validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->